### PR TITLE
Prevent submit bubble

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -255,7 +255,8 @@ Forms.submit = function (e, tmpl) {
 // XXX doc: Forms 'change' and 'submit' event handlers can be overriden using Forms.eventHandlerIsActive method.
 Forms.events = {
   'change, propertyChange': function (e, tmpl) {
-    // Prevent default, we don't want the browser's default handling to happen.
+    // Prevent default, we don't want outer forms or the browser's default handling to happen.
+    e.stopPropagation();
     e.preventDefault();
 
     // Check if the change event is manually disabled
@@ -266,7 +267,8 @@ Forms.events = {
     Forms.change(e, tmpl);
   }
   , 'submit form': function (e, tmpl) {
-    // Prevent default, we don't want the browser's default handling to happen.
+    // Prevent default, we don't want outer forms or the browser's default handling to happen.
+    e.stopPropagation();
     e.preventDefault();
 
     // Check if the submit event is manually disabled

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -255,8 +255,8 @@ Forms.submit = function (e, tmpl) {
 // XXX doc: Forms 'change' and 'submit' event handlers can be overriden using Forms.eventHandlerIsActive method.
 Forms.events = {
   'change, propertyChange': function (e, tmpl) {
-    // Prevent default, we don't want outer forms or the browser's default handling to happen.
-    e.stopPropagation();
+    // Prevent default, we don't want outer templates or the browser's default handling to happen.
+    e.stopImmediatePropagation();
     e.preventDefault();
 
     // Check if the change event is manually disabled
@@ -267,8 +267,8 @@ Forms.events = {
     Forms.change(e, tmpl);
   }
   , 'submit form': function (e, tmpl) {
-    // Prevent default, we don't want outer forms or the browser's default handling to happen.
-    e.stopPropagation();
+    // Prevent default, we don't want outer templates or the browser's default handling to happen.
+    e.stopImmediatePropagation();
     e.preventDefault();
 
     // Check if the submit event is manually disabled

--- a/tests/forms.js
+++ b/tests/forms.js
@@ -347,9 +347,9 @@ Tinytest.add('Forms - Event detection - submit event is bypassed when Forms.subm
   test.notEqual(didCallHandler, true, 'submit event handler not called');
 });
 
-Tinytest.add('Forms - Event detection - submit event does not propagate to outer enclosing forms', function (test) {
-  var didCallInnerHandler = false;
+Tinytest.add('Forms - Event detection - submit event does not propagate to outer enclosing templates', function (test) {
   var didCallOuterHandler = false;
+  var didCallInnerHandler = 0;
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var newForm = makeForm('nestedForms', function () {
     return doc.get();
@@ -364,14 +364,74 @@ Tinytest.add('Forms - Event detection - submit event does not propagate to outer
 
   // inner form
   templateInstance.$('.simpleForm').on('documentSubmit', function (e) {
-    didCallInnerHandler = true;
+    didCallInnerHandler++;
   });
 
   // trigger submit in inner form
   templateInstance.$('.simpleForm').trigger('submit');
 
   test.equal( didCallOuterHandler, false, 'submit handler of outer form called');
-  test.equal( didCallInnerHandler, true, 'submit handler of inner form not-called');
+  test.equal( didCallInnerHandler, 1, 'submit handler of inner form called ' + didCallInnerHandler + ' times!');
+});
+
+Tinytest.add('Forms - Event detection - change event does not propagate to outer enclosing templates', function (test) {
+
+  //
+  // var didCallHandler = false;
+  // var doc = new ReactiveVar({doc: {name: 'joe'}});
+  // var newForm = makeForm('simpleForm', function () {
+  //   return doc.get();
+  // });
+  //
+  // var div = newForm.div;
+  // var templateInstance = newForm.templateInstance;
+  //
+  // Forms.eventHandlerIsActive(templateInstance, 'change', false);
+  //
+  // div.find('input').val('william');
+  //
+  // div.find('form').on('change', function (e) {
+  //   didCallHandler = true;
+  // });
+  //
+  // div.find('input').trigger('change');
+  //
+  // Tracker.flush();
+  //
+  // test.notEqual(templateInstance.doc.get().name, 'william', 'change event not bypassed');
+  // test.equal(didCallHandler, true, 'change event handler not called');
+  //
+  //
+
+  var didCallOuterHandler = false;
+  var didCallInnerHandler = 0;
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var newForm = makeForm('nestedForms', function () {
+    return doc.get();
+  });
+
+  var templateInstance = newForm.templateInstance;
+
+  templateInstance.$('.simpleForm input').val('william');
+
+  // outer form
+  templateInstance.$('.outerForm').on('documentChange', function (e) {
+    didCallOuterHandler = true;
+  });
+
+  // inner form
+  templateInstance.$('.simpleForm').on('documentChange', function (e) {
+    didCallInnerHandler++;
+  });
+
+  // trigger submit in inner form
+  templateInstance.$('.simpleForm input').trigger('change');
+
+  Tracker.flush();
+
+  test.equal(templateInstance.doc.get().name, 'william', 'change event did not update the document');
+  test.equal( didCallOuterHandler, false, 'change handler of outer form called');
+  test.equal( didCallInnerHandler, 1, 'change handler of inner form called ' + didCallInnerHandler + ' times!');
 });
 
 // ####################################################################

--- a/tests/forms.js
+++ b/tests/forms.js
@@ -15,13 +15,17 @@ function makeForm(formName, options) {
     };
 }
 
-Tinytest.add('Forms - initial data', function (test) {
+// ####################################################################
+// ####################################################################
+// Form DOM manipulation tests
+
+Tinytest.add('Forms - DOM - initial data', function (test) {
   var div = makeForm(null, {doc: {name: 'joe'}}).div;
 
   test.equal(div.find('input').val(), 'joe');
 });
 
-Tinytest.add('Forms - reactive data', function (test) {
+Tinytest.add('Forms - DOM - reactive data', function (test) {
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var div = makeForm(null, function () {
     return doc.get();
@@ -37,7 +41,33 @@ Tinytest.add('Forms - reactive data', function (test) {
   test.equal(div.find('input').val(), 'sam');
 });
 
-Tinytest.add('Forms - propertyChange event updates doc', function (test) {
+Tinytest.add('Forms - DOM - form helper', function (test) {
+  var div = makeForm('complexForm', {doc: {name: 'joe'}}).div;
+
+  test.equal(div.find('input').val(), 'joe');
+});
+
+Tinytest.add('Forms - DOM - reactive form helper', function (test) {
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var div = makeForm('complexForm', function () {
+    return doc.get();
+  }).div;
+
+  doc.set({
+    doc: {
+      name: 'sam'
+    }
+  });
+
+  Tracker.flush();
+  test.equal(div.find('input').val(), 'sam');
+});
+
+// ####################################################################
+// ####################################################################
+// Form document updating tests
+
+Tinytest.add('Forms - document updates - propertyChange event updates doc', function (test) {
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var div = makeForm(null, function () {
     return doc.get();
@@ -50,7 +80,7 @@ Tinytest.add('Forms - propertyChange event updates doc', function (test) {
   test.equal(div.find('input').val(), 'william');
 });
 
-Tinytest.add('Forms - custom change values updates doc', function (test) {
+Tinytest.add('Forms - document updates - custom change values updates doc', function (test) {
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var div = makeForm(null, function () {
     return doc.get();
@@ -66,122 +96,7 @@ Tinytest.add('Forms - custom change values updates doc', function (test) {
   test.equal(div.find('input').val(), 'bill');
 });
 
-Tinytest.add('Forms - documentChange event is triggered', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentChange', function (e) {
-    e.preventDefault();
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    didCallHandler = true;
-  });
-
-  div.find('input').val('joe');
-  div.find('input').trigger('change');
-
-  test.equal(didCallHandler, true);
-});
-
-Tinytest.add('Forms - documentSubmit event is triggered', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentSubmit', function (e) {
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    didCallHandler = true;
-  });
-
-  div.find('form').trigger('submit');
-  test.equal(didCallHandler, true);
-});
-
-Tinytest.add('Forms - documentSubmit event is not triggered when form is invalid', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentSubmit', function (e) {
-    e.preventDefault();
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    didCallHandler = true;
-  });
-
-  div.find('form').trigger('submit');
-  test.equal(didCallHandler, false);
-});
-
-Tinytest.add('Forms - documentInvalid event is triggered when form is invalid', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentInvalid', function (e) {
-    e.preventDefault();
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    didCallHandler = true;
-  });
-
-  div.find('form').trigger('submit');
-  test.equal(didCallHandler, true);
-});
-
-Tinytest.add('Forms - submit event receives errors when form is invalid', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentInvalid', function (e) {
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    test.equal(_.pluck(e.errors, 'name'), ['name']);
-    didCallHandler = true;
-  });
-
-  div.find('input').trigger('submit');
-  test.equal(didCallHandler, true, 'submit handler not called');
-});
-
-Tinytest.add('Forms - documentInvalid event recieves errors', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
-  var div = makeForm(null, function () {
-    return doc.get();
-  }).div;
-
-  div.on('documentInvalid', function (e) {
-    test.equal(e.doc, {
-      name: 'joe'
-    });
-    test.equal(_.pluck(e.errors, 'name'), ['name']);
-    didCallHandler = true;
-  });
-
-  div.find('form').trigger('submit');
-  test.equal(didCallHandler, true);
-});
-
-Tinytest.add('Forms - nested data', function (test) {
+Tinytest.add('Forms - document updates - nested data', function (test) {
   var div = makeForm(null, {doc: { profile: { name: 'joe'}, emails: ['joe@example.com']}}).div;
 
   Blaze._withCurrentView(Blaze.getView(div.find('input')[0]), function () {
@@ -208,77 +123,32 @@ Tinytest.add('Forms - nested data', function (test) {
   });
 });
 
-Tinytest.add('Forms - form helper', function (test) {
-  var div = makeForm('complexForm', {doc: {name: 'joe'}}).div;
-
-  test.equal(div.find('input').val(), 'joe');
-});
-
-Tinytest.add('Forms - reactive form helper', function (test) {
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var div = makeForm('complexForm', function () {
-    return doc.get();
-  }).div;
-
-  doc.set({
-    doc: {
-      name: 'sam'
-    }
-  });
-
-  Tracker.flush();
-  test.equal(div.find('input').val(), 'sam');
-});
-
 // ####################################################################
 // ####################################################################
 // Form event triggering tests
 
-
-// ####################################################################
-// ####################################################################
-// Form event detection tests
-Tinytest.add('Forms - Event detection - change event updates doc', function (test) {
+Tinytest.add('Forms - Events triggered by Forms - documentChange event is triggered', function (test) {
+  var didCallHandler = false;
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var div = makeForm(null, function () {
     return doc.get();
   }).div;
 
-  div.find('input').val('william');
-  div.find('input').trigger('change');
-
-  Tracker.flush();
-  test.equal(doc.get().doc.name, 'william');
-});
-
-Template.simpleForm.events({
-  'mockSubmit': function (e, tmpl) {
-    Forms.submit( e, tmpl );
-  }
-});
-
-Tinytest.add('Forms - Event detection - submit event is triggered', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var newForm = makeForm(null, function () {
-    return doc.get();
-  });
-
-  var templateInstance = newForm.templateInstance;
-
-  newForm.div.find('form').on('submit', function (e) {
+  div.on('documentChange', function (e) {
     e.preventDefault();
-    // test.equal(e.doc, {
-    //   name: 'joe'
-    // });
+    test.equal(e.doc, {
+      name: 'joe'
+    });
     didCallHandler = true;
   });
 
-  templateInstance.$('input').trigger('submit');
+  div.find('input').val('joe');
+  div.find('input').trigger('change');
+
   test.equal(didCallHandler, true);
 });
 
-Tinytest.add('Forms - Event detection - submit method is called', function (test) {
+Tinytest.add('Forms - Events triggered by Forms - documentSubmit event is triggered', function (test) {
   var didCallHandler = false;
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var div = makeForm(null, function () {
@@ -292,16 +162,91 @@ Tinytest.add('Forms - Event detection - submit method is called', function (test
     didCallHandler = true;
   });
 
-  div.on('mockSubmit', function (e) {
-    test.equal(_.has(e, 'doc'), true);
-  });
-
-  div.find('input').trigger('mockSubmit');
-
+  div.find('form').trigger('submit');
   test.equal(didCallHandler, true);
 });
 
-Tinytest.add('Forms - Event detection - change event is bypassed when Forms.changeEventIsActive is set to "false"', function (test) {
+Tinytest.add('Forms - Events triggered by Forms - documentSubmit event is not triggered when form is invalid', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.on('documentSubmit', function (e) {
+    e.preventDefault();
+    test.equal(e.doc, {
+      name: 'joe'
+    });
+    didCallHandler = true;
+  });
+
+  div.find('form').trigger('submit');
+  test.equal(didCallHandler, false);
+});
+
+Tinytest.add('Forms - Events triggered by Forms - documentInvalid event is triggered when form is invalid', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.on('documentInvalid', function (e) {
+    e.preventDefault();
+    test.equal(e.doc, {
+      name: 'joe'
+    });
+    didCallHandler = true;
+  });
+
+  div.find('form').trigger('submit');
+  test.equal(didCallHandler, true);
+});
+
+// ####################################################################
+// ####################################################################
+// Form event handling tests
+
+Template.simpleForm.events({
+  'mockSubmit': function (e, tmpl) {
+    Forms.submit( e, tmpl );
+  }
+});
+
+Tinytest.add('Forms - Event handling - documentInvalid event receives errors', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.on('documentInvalid', function (e) {
+    test.equal(e.doc, {
+      name: 'joe'
+    });
+    test.equal(_.pluck(e.errors, 'name'), ['name']);
+    didCallHandler = true;
+  });
+
+  div.find('form').trigger('submit');
+  test.equal(didCallHandler, true);
+});
+
+Tinytest.add('Forms - Event handling - change event updates doc', function (test) {
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.find('input').val('william');
+  div.find('input').trigger('change');
+
+  Tracker.flush();
+  test.equal(doc.get().doc.name, 'william');
+});
+
+Tinytest.add('Forms - Event handling - change event is bypassed when Forms.changeEventIsActive is set to "false"', function (test) {
   var didCallHandler = false;
   var doc = new ReactiveVar({doc: {name: 'joe'}});
   var newForm = makeForm('simpleForm', function () {
@@ -327,82 +272,7 @@ Tinytest.add('Forms - Event detection - change event is bypassed when Forms.chan
   test.equal(didCallHandler, true, 'change event handler not called');
 });
 
-Tinytest.add('Forms - Event detection - submit event is bypassed when Forms.submitEventIsActive is set to "false"', function (test) {
-  var didCallHandler = false;
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var newForm = makeForm('simpleForm', function () {
-    return doc.get();
-  });
-
-  var div = newForm.div;
-  var templateInstance = newForm.templateInstance;
-
-  Forms.eventHandlerIsActive(templateInstance, 'submit', false);
-
-  templateInstance.$('form').on('documentSubmit', function (e) {
-    didCallHandler = true;
-  });
-
-  templateInstance.$('input').trigger('submit');
-  test.notEqual(didCallHandler, true, 'submit event handler not called');
-});
-
-Tinytest.add('Forms - Event detection - submit event does not propagate to outer enclosing templates', function (test) {
-  var didCallOuterHandler = false;
-  var didCallInnerHandler = 0;
-  var doc = new ReactiveVar({doc: {name: 'joe'}});
-  var newForm = makeForm('nestedForms', function () {
-    return doc.get();
-  });
-
-  var templateInstance = newForm.templateInstance;
-
-  // outer form
-  templateInstance.$('.outerForm').on('documentSubmit', function (e) {
-    didCallOuterHandler = true;
-  });
-
-  // inner form
-  templateInstance.$('.simpleForm').on('documentSubmit', function (e) {
-    didCallInnerHandler++;
-  });
-
-  // trigger submit in inner form
-  templateInstance.$('.simpleForm').trigger('submit');
-
-  test.equal( didCallOuterHandler, false, 'submit handler of outer form called');
-  test.equal( didCallInnerHandler, 1, 'submit handler of inner form called ' + didCallInnerHandler + ' times!');
-});
-
-Tinytest.add('Forms - Event detection - change event does not propagate to outer enclosing templates', function (test) {
-
-  //
-  // var didCallHandler = false;
-  // var doc = new ReactiveVar({doc: {name: 'joe'}});
-  // var newForm = makeForm('simpleForm', function () {
-  //   return doc.get();
-  // });
-  //
-  // var div = newForm.div;
-  // var templateInstance = newForm.templateInstance;
-  //
-  // Forms.eventHandlerIsActive(templateInstance, 'change', false);
-  //
-  // div.find('input').val('william');
-  //
-  // div.find('form').on('change', function (e) {
-  //   didCallHandler = true;
-  // });
-  //
-  // div.find('input').trigger('change');
-  //
-  // Tracker.flush();
-  //
-  // test.notEqual(templateInstance.doc.get().name, 'william', 'change event not bypassed');
-  // test.equal(didCallHandler, true, 'change event handler not called');
-  //
-  //
-
+Tinytest.add('Forms - Event handling - change event does not propagate to outer enclosing templates', function (test) {
   var didCallOuterHandler = false;
   var didCallInnerHandler = 0;
   var doc = new ReactiveVar({doc: {name: 'joe'}});
@@ -434,9 +304,120 @@ Tinytest.add('Forms - Event detection - change event does not propagate to outer
   test.equal( didCallInnerHandler, 1, 'change handler of inner form called ' + didCallInnerHandler + ' times!');
 });
 
+Tinytest.add('Forms - Event handling - submit event receives errors when form is invalid', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.on('documentInvalid', function (e) {
+    test.equal(e.doc, {
+      name: 'joe'
+    });
+    test.equal(_.pluck(e.errors, 'name'), ['name']);
+    didCallHandler = true;
+  });
+
+  div.find('input').trigger('submit');
+  test.equal(didCallHandler, true, 'submit handler not called');
+});
+
+Tinytest.add('Forms - Event handling - submit event is triggered', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var newForm = makeForm(null, function () {
+    return doc.get();
+  });
+
+  var templateInstance = newForm.templateInstance;
+
+  newForm.div.find('form').on('submit', function (e) {
+    e.preventDefault();
+    // test.equal(e.doc, {
+    //   name: 'joe'
+    // });
+    didCallHandler = true;
+  });
+
+  templateInstance.$('input').trigger('submit');
+  test.equal(didCallHandler, true);
+});
+
+Tinytest.add('Forms - Event handling - submit method is called', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var div = makeForm(null, function () {
+    return doc.get();
+  }).div;
+
+  div.on('documentSubmit', function (e) {
+    test.equal(e.doc, {
+      name: 'joe'
+    });
+    didCallHandler = true;
+  });
+
+  div.on('mockSubmit', function (e) {
+    test.equal(_.has(e, 'doc'), true);
+  });
+
+  div.find('input').trigger('mockSubmit');
+
+  test.equal(didCallHandler, true);
+});
+
+Tinytest.add('Forms - Event handling - submit event is bypassed when Forms.submitEventIsActive is set to "false"', function (test) {
+  var didCallHandler = false;
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var newForm = makeForm('simpleForm', function () {
+    return doc.get();
+  });
+
+  var div = newForm.div;
+  var templateInstance = newForm.templateInstance;
+
+  Forms.eventHandlerIsActive(templateInstance, 'submit', false);
+
+  templateInstance.$('form').on('documentSubmit', function (e) {
+    didCallHandler = true;
+  });
+
+  templateInstance.$('input').trigger('submit');
+  test.notEqual(didCallHandler, true, 'submit event handler not called');
+});
+
+Tinytest.add('Forms - Event handling - submit event does not propagate to outer enclosing templates', function (test) {
+  var didCallOuterHandler = false;
+  var didCallInnerHandler = 0;
+  var doc = new ReactiveVar({doc: {name: 'joe'}});
+  var newForm = makeForm('nestedForms', function () {
+    return doc.get();
+  });
+
+  var templateInstance = newForm.templateInstance;
+
+  // outer form
+  templateInstance.$('.outerForm').on('documentSubmit', function (e) {
+    didCallOuterHandler = true;
+  });
+
+  // inner form
+  templateInstance.$('.simpleForm').on('documentSubmit', function (e) {
+    didCallInnerHandler++;
+  });
+
+  // trigger submit in inner form
+  templateInstance.$('.simpleForm').trigger('submit');
+
+  test.equal( didCallOuterHandler, false, 'submit handler of outer form called');
+  test.equal( didCallInnerHandler, 1, 'submit handler of inner form called ' + didCallInnerHandler + ' times!');
+});
+
 // ####################################################################
 // ####################################################################
 // Form validation tests
+
 
 Tinytest.add('Forms - Validation - custom validators - reactive error message displayed', function (test) {
   var doc = new ReactiveVar({doc: {name: 'joe'}, schema: {name: function () {return false;}}});

--- a/tests/simpleForm.html
+++ b/tests/simpleForm.html
@@ -1,5 +1,5 @@
 <template name="simpleForm">
-  <form>
+  <form class="simpleForm">
     <input name="name" value={{value "name"}}>
     <span class="error">{{error "name"}}</span>
   </form>
@@ -10,5 +10,12 @@
       <input name="name" value={{value "name"}}>
       <span class="error">{{error "name"}}</span>
     {{/with}}
+  </form>
+</template>
+<template name="nestedForms">
+  <form class="outerForm">
+    {{> simpleForm doc=doc}}
+    <input name="name" value={{value "name"}}>
+    <span class="error">{{error "name"}}</span>
   </form>
 </template>

--- a/tests/simpleForm.html
+++ b/tests/simpleForm.html
@@ -1,6 +1,6 @@
 <template name="simpleForm">
   <form class="simpleForm">
-    <input name="name" value={{value "name"}}>
+    <input class="innerinput" name="name" value={{value "name"}}>
     <span class="error">{{error "name"}}</span>
   </form>
 </template>
@@ -14,8 +14,8 @@
 </template>
 <template name="nestedForms">
   <form class="outerForm">
-    {{> simpleForm doc=doc}}
     <input name="name" value={{value "name"}}>
     <span class="error">{{error "name"}}</span>
   </form>
+  {{> simpleForm doc=doc}}
 </template>


### PR DESCRIPTION
change/submit events do not propagate to parrent templates & tests.
i.e. change or submit events do not fire twice if a Forms template is enclosed in another template. 
