### PR TITLE
Create errorMessage helper

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -166,6 +166,25 @@ function makeErrorGetter(collectionName) {
   };
 }
 
+function makeErrorMessageGetter(collectionName) {
+  return function (fieldName) {
+    var form = this
+      , error;
+    if (!this[collectionName])
+      this[collectionName] = new Mongo.Collection(null);
+    if (_.isString(fieldName)) {
+      error = this[collectionName].findOne({
+        name: fieldName
+      });
+    } else {
+      error = this[collectionName].findOne();
+    }
+    if (! _.isUndefined(error) && ! _.isUndefined(error.message))
+        return error.message;
+    return error;
+  };
+}
+
 function makeHelpers(helpers) {
   var result = {};
   _.each(helpers, function (helper, key) {
@@ -395,6 +414,7 @@ Forms.helpers({
   , schema: makeGetterHelper('schema')
   , errors: makeGetterHelper('errors')
   , error: makeErrorGetter('_errors')
+  , errorMessage: makeErrorMessageGetter('_errors')
   , isValid: function () {
     return !this.error.apply(this, arguments);
   }


### PR DESCRIPTION
The new `errorMessage` helper can be used inside a template like so:

```
{{errorMessage 'fieldName'}}
```

This closes #21 
