### PR TITLE
Fix windows incompatablility

### DIFF
--- a/.versions
+++ b/.versions
@@ -23,7 +23,7 @@ html-tools@1.0.5
 htmljs@1.0.5
 id-map@1.0.4
 jquery@1.11.4
-local-test:useful:forms@1.0.3
+local-test:useful:forms@1.0.4
 logging@1.0.8
 meteor@1.1.7
 minifiers@1.1.7
@@ -47,6 +47,6 @@ tinytest@1.0.6
 tracker@1.0.8
 ui@1.0.8
 underscore@1.0.4
-useful:forms@1.0.3
+useful:forms@1.0.4
 webapp@1.2.2
 webapp-hashing@1.0.5

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
 	name: 'useful:forms',
-	version: '1.0.3',
+	version: '1.0.4',
 	summary: 'Fully reactive forms which don\'t mess with your html',
 	git: 'https://github.com/usefulio/forms',
 	documentation: 'README.md'
@@ -16,6 +16,7 @@ Package.onUse(function(api) {
 		'templating'
 		, 'underscore'
 		, 'check'
+		, 'tracker'
 	], ['client', 'server']);
 
 	api.use([
@@ -41,7 +42,7 @@ Package.onUse(function(api) {
 
 	// ====== EXPORTS =======
 
-	api.export('Forms');
+	api.export('Forms', 'client');
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
Only export the Forms global to the client - for some reason failing to do this didn't trigger any errors on mac, but threw a reference error on windows. Anyway, the package is only relevant to the client, so we shouldn't be exporting the Forms global to the server.
